### PR TITLE
doc: clarify quickfixlist abbreviation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,27 +189,27 @@ EOF
 Mappings are fully customizable.
 Many familiar mapping patterns are setup as defaults.
 
-| Mappings       | Action                                      |
-|----------------|---------------------------------------------|
-| `<C-n>/<Down>` | Next item                                   |
-| `<C-p>/<Up>`   | Previous item                               |
-| `j/k`          | Next/previous (in normal mode)              |
-| `H/M/L`        | Select High/Middle/Low (in normal mode)     |
-| 'gg/G'         | Select the first/last item (in normal mode) |
-| `<CR>`         | Confirm selection                           |
-| `<C-x>`        | Go to file selection as a split             |
-| `<C-v>`        | Go to file selection as a vsplit            |
-| `<C-t>`        | Go to a file in a new tab                   |
-| `<C-u>`        | Scroll up in preview window                 |
-| `<C-d>`        | Scroll down in preview window               |
-| `<C-/>`      | Show mappings for picker actions (insert mode)|
-| `?`          | Show mappings for picker actions (normal mode)|
-| `<C-c>`        | Close telescope                             |
-| `<Esc>`        | Close telescope (in normal mode)            |
-| `<Tab>`        | Toggle selection and move to next selection |
-| `<S-Tab>`      | Toggle selection and move to prev selection |
-| `<C-q>`        | Send all items not filtered to qflist       |
-| `<M-q>`        | Send all selected items to qflist           |
+| Mappings       | Action                                               |
+|----------------|------------------------------------------------------|
+| `<C-n>/<Down>` | Next item                                            |
+| `<C-p>/<Up>`   | Previous item                                        |
+| `j/k`          | Next/previous (in normal mode)                       |
+| `H/M/L`        | Select High/Middle/Low (in normal mode)              |
+| 'gg/G'         | Select the first/last item (in normal mode)          |
+| `<CR>`         | Confirm selection                                    |
+| `<C-x>`        | Go to file selection as a split                      |
+| `<C-v>`        | Go to file selection as a vsplit                     |
+| `<C-t>`        | Go to a file in a new tab                            |
+| `<C-u>`        | Scroll up in preview window                          |
+| `<C-d>`        | Scroll down in preview window                        |
+| `<C-/>`        | Show mappings for picker actions (insert mode)       |
+| `?`            | Show mappings for picker actions (normal mode)       |
+| `<C-c>`        | Close telescope                                      |
+| `<Esc>`        | Close telescope (in normal mode)                     |
+| `<Tab>`        | Toggle selection and move to next selection          |
+| `<S-Tab>`      | Toggle selection and move to prev selection          |
+| `<C-q>`        | Send all items not filtered to quickfixlist (qflist) |
+| `<M-q>`        | Send all selected items to qflist                    |
 
 
 To see the full list of mappings, check out `lua/telescope/mappings.lua` and the


### PR DESCRIPTION
This really killed me when I was looking at this plugin for the first time. I spent like 20 minutes googling how to get search results into the quickfixlist because ctrl-F for "quickfixlist" on the README yielded no results!

There's nothing wrong with using the abbreviation in some places, but it should appear at least once in the form of `abbreviation (abbr.)`. That is, spelling it out next to the abbreviation at least once shows the reader the abbreviation they can search for next to learn more.